### PR TITLE
Header: Replace PDF guide for Google Drive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 data/profile_images/** filter=lfs diff=lfs merge=lfs -text
-public/assets/** filter=lfs diff=lfs merge=lfs -text
 public/profile_images/** filter=lfs diff=lfs merge=lfs -text

--- a/public/assets/resumeguide.pdf
+++ b/public/assets/resumeguide.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d568ae333ec5fc7f877ea6ee3e4e9067710d14bec3b192c541e42f2ea7abd64
-size 8112650

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -50,7 +50,7 @@ const Header = () => (
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href={process.env.PUBLIC_URL + "/assets/resumeguide.pdf"}
+            href="https://drive.google.com/file/d/1w7zlMuGY_7hVXeW0LaNKXWWjLRt3ic4G/view?usp=sharing"
           >
             here
           </a>{" "}


### PR DESCRIPTION
This reduces bandwidth usage on GH Pages.