### PR TITLE
SearchBar: Add wave name to placeholder text

### DIFF
--- a/src/components/search-bar.jsx
+++ b/src/components/search-bar.jsx
@@ -100,7 +100,7 @@ function SearchBar({ value, waveIndex, onSearchChange, onSearchSelect }) {
         suggestions={suggestions}
         inputProps={{
           onChange,
-          placeholder: "Search for mentors...",
+          placeholder: `Search for mentors in ${waves[waveIndex].name}...`,
           value,
         }}
       />


### PR DESCRIPTION
This addresses the previous comment made by @RyanRTJJ that people might think the search bar would search across multiple waves.