### PR TITLE
Ensure modal opens on load if there is a URL hash.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -49,7 +49,7 @@ function App() {
       // If modal is not open and `activeMentorId === null`, this must be the
       // initial load. Check for a hash, and open the modal if such an ID
       // exists.
-      if (activeMentorId === null) {
+      if (activeMentorId === "") {
         if (!ensureModalFromHash()) {
           // Otherwise, set a default ID, but do not open the modal.
           setActiveMentorId("");

--- a/src/App.js
+++ b/src/App.js
@@ -46,7 +46,7 @@ function App() {
     if (isModalOpen) {
       setHash(activeMentorId);
     } else {
-      // If modal is not open and `activeMentorId === null`, this must be the
+      // If modal is not open and `activeMentorId === ""`, this must be the
       // initial load. Check for a hash, and open the modal if such an ID
       // exists.
       if (activeMentorId === "") {


### PR DESCRIPTION
@wei2912 here's the issue you mentioned. Seems like we've addressed this before, but maybe it got wiped in a merge?