### PR TITLE
Header: Fix missing images

### DIFF
--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -1,2 +1,3 @@
-export const advisoryLogo = require("./advisory-logo.png");
-export const advisoryMentorshipLogo = require("./advisory-mentorship-logo.png");
+export const advisoryLogo = require("./advisory-logo.png").default;
+export const advisoryMentorshipLogo = require("./advisory-mentorship-logo.png")
+  .default;


### PR DESCRIPTION
Previously, the header had missing images:

![image](https://user-images.githubusercontent.com/2070423/100459314-41490e80-3100-11eb-9e76-dcd1b1b04001.png)

Inspection showed that the images weren't loaded by `webpack`:

![image](https://user-images.githubusercontent.com/2070423/100459388-5a51bf80-3100-11eb-82fd-bf3435bc6084.png)

This was due to a change in `file-loader`. For information on the fix, see
https://stackoverflow.com/questions/59070216/webpack-file-loader-outputs-object-module.