### PR TITLE
load_mentors.js: Return stringified JSON directly

### DIFF
--- a/scripts/load_mentors.js
+++ b/scripts/load_mentors.js
@@ -20,8 +20,5 @@ exports.handler = async (event) => {
       fetchNextPage();
     });
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify(mentors),
-  };
+  return JSON.stringify({ mentors });
 };


### PR DESCRIPTION
This simplifies the return format of the lambda and follows the guidelines at https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2. By returning a valid JSON string, API Gateway will infer the remaining parameters.

After this PR, API requests should return the JSON data directly and as `application/json` rather than plain text.