### PR TITLE
profile-card: Add industry tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://mentorship.advisory.sg/",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^4.11.4",
     "body-scroll-lock": "^3.1.5",
     "danger": "^10.6.4",
     "fuse.js": "^6.4.6",

--- a/src/components/profile-card.css
+++ b/src/components/profile-card.css
@@ -19,6 +19,7 @@
   width: 100%;
   overflow: hidden;
   background-size: cover;
+  margin-bottom: 8px;
 }
 .card-image {
   width: 100%;
@@ -31,6 +32,12 @@
   .card-image {
     height: 120px;
   }
+}
+.card-chip {
+  margin: 4px auto;
+  width: 80%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .card-descriptors {
   flex: 1;

--- a/src/components/profile-card.jsx
+++ b/src/components/profile-card.jsx
@@ -1,5 +1,6 @@
 import LazyLoad from "react-lazyload";
 import React from "react";
+import Chip from "@material-ui/core/Chip";
 
 import "./profile-card.css";
 
@@ -22,6 +23,14 @@ const ProfileCard = ({ mentor, onReadMore }) => (
         />
       </LazyLoad>
     </div>
+    {mentor.industry && (
+      <Chip
+        className="card-chip"
+        size="small"
+        label={mentor.industry}
+        color="primary"
+      />
+    )}
     <div className="card-descriptors">
       <div className="card-name">{mentor.name}</div>
       {mentor.role && <div className="card-desc">{mentor.role}</div>}


### PR DESCRIPTION
Fixes https://github.com/AdvisorySG/mentorship-page/issues/282. Should scale nicely to small screens, since the tag is set at 80% of width.

![image](https://user-images.githubusercontent.com/2070423/119267210-1efffb80-bc20-11eb-86d7-3c1d280ceaf7.png)
