### PR TITLE
profile-card: Lazy load entire cards

### DIFF
--- a/src/components/profile-card.jsx
+++ b/src/components/profile-card.jsx
@@ -13,15 +13,13 @@ const ReadMore = ({ onReadMore }) => (
 );
 
 const ProfileCard = ({ mentor, onReadMore }) => (
-  <div className="card">
+  <LazyLoad className="card" height={160} offset={800} once>
     <div className="card-image-region">
-      <LazyLoad height={160} offset={480} once>
-        <img
-          className="card-image"
-          src={process.env.PUBLIC_URL + mentor.thumbnailImageUrl}
-          alt={mentor.name}
-        />
-      </LazyLoad>
+      <img
+        className="card-image"
+        src={process.env.PUBLIC_URL + mentor.thumbnailImageUrl}
+        alt={mentor.name}
+      />
     </div>
     {mentor.industry && (
       <Chip
@@ -39,7 +37,7 @@ const ProfileCard = ({ mentor, onReadMore }) => (
       )}
     </div>
     <ReadMore onReadMore={onReadMore} />
-  </div>
+  </LazyLoad>
 );
 
 export default ProfileCard;


### PR DESCRIPTION
Resolves https://github.com/AdvisorySG/mentorship-page/issues/301, although it does not fix the performance issues entirely (even on Production build; try typing "National University of Singapore" into School and experience the lag).

I'm not sure if the debounce method we're using is effective, so we probably should look into finding something better. I assume it doesn't actually block requests, just delays them.