### PR TITLE
Prevent layout shifting when searching

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,10 @@
   text-align: center;
 }
 
+.results {
+  min-height: 100vh;
+}
+
 .results-text {
   font-style: italic;
   text-align: center;

--- a/src/App.js
+++ b/src/App.js
@@ -90,7 +90,7 @@ function App() {
           </small>
         </p>
         {hasMentorsFetched ? (
-          <div>
+          <div className="results">
             <SearchBar
               mentors={mentors}
               setHasSearch={setHasSearch}


### PR DESCRIPTION
Set a minimum height of the full screen height to prevent the scroll position from changing when results are filtered out.