### PR TITLE
Use Airtable's record ID as mentorId

### DIFF
--- a/scripts/load_mentors.js
+++ b/scripts/load_mentors.js
@@ -16,7 +16,7 @@ exports.handler = async (event) => {
   await base("4 Tech")
     .select({ sort: [{ field: "First Name", direction: "asc" }] })
     .eachPage((records, fetchNextPage) => {
-      mentors.push(...records.map((record) => record.fields));
+      mentors.push(...records.map(({ id, fields }) => ({ id, ...fields })));
       fetchNextPage();
     });
 

--- a/src/mentors.js
+++ b/src/mentors.js
@@ -8,10 +8,9 @@ export const fetchMentors = async (setMentors, setMentorIds) => {
     .then((response) => response.json())
     .then((data) => data.mentors);
 
-  const mentorIdsMap = new Map();
-
   mentorsData.forEach(
     ({
+      id: mentorId,
       Photo: images,
       Name: name,
       Biography: fullBio,
@@ -28,17 +27,6 @@ export const fetchMentors = async (setMentors, setMentorIds) => {
         images.length > 0 && images[0].thumbnails
           ? images[0].thumbnails.large.url
           : undefined;
-
-      // The regex below serves to omit non-alphanumeric characters from name variable
-      let mentorId = name.replace(/\W/g, "");
-      let count = mentorIdsMap.get(mentorId);
-      if (count === undefined) {
-        mentorIdsMap.set(mentorId, 1);
-      } else {
-        count++;
-        mentorIdsMap.set(mentorId, count);
-        mentorId = mentorId + count;
-      }
 
       mentors[mentorId] = {
         courseOfStudy,


### PR DESCRIPTION
As discussed, this PR utilises Airtable's record ID as an unique identifier for each mentor. This will prevent issues with mentors having the same names if the order of rows, as returned by Airtable, were to change, since sorting is done by the first name.