### PR TITLE
Add padding to privacy statement

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,8 @@
   max-width: 90ch;
   text-align: justify;
   text-align-last: left;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .results {


### PR DESCRIPTION
Mainly added left and right padding of 16px to privacy statement. In effect regardless of mobile/ desktop view

Before

![image](https://user-images.githubusercontent.com/18213722/164469230-afbf505f-a00d-4797-bae3-6a74de1acbf4.png)

After

![image](https://user-images.githubusercontent.com/18213722/164468758-b5f304be-7784-44cd-97ec-a624ac4a131a.png)
![image](https://user-images.githubusercontent.com/18213722/164468846-26d3c573-c6c0-40aa-8d64-56ce8dd227b8.png)
![image](https://user-images.githubusercontent.com/18213722/164469058-6faf7d6e-53c0-4d73-90f4-0eb7b1c4d01d.png)
