### PR TITLE
Increase z-index of filter panel to lay over header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,3 +43,7 @@
 .sui-result__label {
   color: "#7c7c72";
 }
+
+.sui-layout-sidebar.sui-layout-sidebar--toggled {
+  z-index: 1101;
+}


### PR DESCRIPTION
I added a style to the filter panel (selected with the CSS selectors `.sui-layout-sidebar.sui-layout-sidebar--toggled`) to increase the z-index to 1 above the header's z-index of 1100

![image](https://user-images.githubusercontent.com/18213722/164481453-516a4ec0-39da-43d7-ac08-96025d259e02.png)
