### PR TITLE
load_mentors: Enforce unique industries

### DIFF
--- a/scripts/load_mentors.js
+++ b/scripts/load_mentors.js
@@ -24,10 +24,14 @@ const formatMentor = (id, waveId, fields) => ({
       ? fields.Photo[0].url
       : PLACEHOLDER_THUMBNAIL_URL,
   industries: [
-    fields["Industry 1"] ?? [],
-    fields["Industry 2"] ?? [],
-    fields["Industry 3"] ?? [],
-  ].flat(),
+    ...new Set(
+      [
+        fields["Industry 1"] ?? [],
+        fields["Industry 2"] ?? [],
+        fields["Industry 3"] ?? [],
+      ].flat()
+    ),
+  ],
   name: fields.Name,
   organisation: fields.Organisation,
   role: fields["Job Title"],


### PR DESCRIPTION
This PR enforces unique industries.

**This code has not been tested. After merging, please wait for the build to finish and then wait an additional 20 minutes for the Elasticsearch data to refresh, then verify that no more duplicate industries exist!**

Sample test cases:

![image](https://user-images.githubusercontent.com/2070423/166196004-a298605b-9bbb-4e3c-a76e-87f9b85884f6.png)
