### PR TITLE
Only reindex modified mentors

### DIFF
--- a/scripts/load_mentors.js
+++ b/scripts/load_mentors.js
@@ -49,30 +49,8 @@ const formatMentor = (id, waveId, fields) => ({
       : PLACEHOLDER_THUMBNAIL_URL,
   wave_id: waveId,
   wave_name: WAVE_INFO[waveId].name,
+  last_modified_time: fields["Last Modified Time"],
 });
-
-function deepEqual(object1, object2) {
-  const keys1 = Object.keys(object1);
-  const keys2 = Object.keys(object2);
-  if (keys1.length !== keys2.length) {
-    return false;
-  }
-  for (const key of keys1) {
-    const val1 = object1[key];
-    const val2 = object2[key];
-    const areObjects = isObject(val1) && isObject(val2);
-    if (
-      (areObjects && !deepEqual(val1, val2)) ||
-      (!areObjects && val1 !== val2)
-    ) {
-      return false;
-    }
-  }
-  return true;
-}
-function isObject(object) {
-  return object != null && typeof object === "object";
-}
 
 exports.handler = async (event) => {
   const mentors = [];
@@ -125,7 +103,9 @@ exports.handler = async (event) => {
     const { id: mentorId } = result;
     if (!mentorIds.has(mentorId)) {
       oldMentorIds.push(mentorId);
-    } else if (!deepEqual(mentorMap.get(mentorId), result)) {
+    } else if (
+      mentorMap.get(mentorId).last_modified_time !== result.last_modified_time
+    ) {
       modifiedMentorIds.push(mentorId);
     }
   }

--- a/scripts/load_mentors.js
+++ b/scripts/load_mentors.js
@@ -110,6 +110,7 @@ exports.handler = async (event) => {
 
   console.log(`No. of Elasticsearch mentors: ${count}`);
   console.log(`No. of old mentors: ${oldMentorIds.length}`);
+  console.log(`No. of modified mentors: ${modifiedMentorIds.length}`);
 
   if (oldMentorIds.length > 0) {
     console.log("Deleting old mentors...");

--- a/scripts/load_mentors.js
+++ b/scripts/load_mentors.js
@@ -51,6 +51,29 @@ const formatMentor = (id, waveId, fields) => ({
   wave_name: WAVE_INFO[waveId].name,
 });
 
+function deepEqual(object1, object2) {
+  const keys1 = Object.keys(object1);
+  const keys2 = Object.keys(object2);
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+  for (const key of keys1) {
+    const val1 = object1[key];
+    const val2 = object2[key];
+    const areObjects = isObject(val1) && isObject(val2);
+    if (
+      (areObjects && !deepEqual(val1, val2)) ||
+      (!areObjects && val1 !== val2)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+function isObject(object) {
+  return object != null && typeof object === "object";
+}
+
 exports.handler = async (event) => {
   const mentors = [];
 
@@ -89,7 +112,7 @@ exports.handler = async (event) => {
 
   const mentorMap = new Map(mentors.map((mentor) => [mentor.id, mentor]));
   const modifiedMentorIds = [];
-  
+
   console.log(`No. of Airtable mentors: ${mentorIds.size}`);
 
   let count = 0;
@@ -102,8 +125,7 @@ exports.handler = async (event) => {
     const { id: mentorId } = result;
     if (!mentorIds.has(mentorId)) {
       oldMentorIds.push(mentorId);
-    }
-    if (mentorMap.get(mentorId) !== result) {
+    } else if (!deepEqual(mentorMap.get(mentorId), result)) {
       modifiedMentorIds.push(mentorId);
     }
   }


### PR DESCRIPTION
I modified the code to pick out only the mentors that were modified and index them. This should conserve network bandwidth on reindexing.