### PR TITLE
Filter out nameless entries

### DIFF
--- a/scripts/load_mentors.js
+++ b/scripts/load_mentors.js
@@ -99,7 +99,6 @@ exports.handler = async (event) => {
 
   const mentorMap = new Map(mentors.map((mentor) => [mentor.id, mentor]));
   const deletedMentorIds = [];
-  const modifiedMentorIds = [];
   const unmodifiedMentorIds = new Set();
 
   console.log(`No. of Airtable mentors: ${mentorMap.size}`);
@@ -112,13 +111,14 @@ exports.handler = async (event) => {
   for await (const result of scrollSearch) {
     count += 1;
     const { id: mentorId } = result;
-    if (mentorMap.get(mentorId) === undefined) {
+    if (
+      mentorMap.get(mentorId) === undefined ||
+      !mentorMap.get(mentorId).name
+    ) {
       deletedMentorIds.push(mentorId);
     } else if (
-      mentorMap.get(mentorId).last_modified_time !== result.last_modified_time
+      mentorMap.get(mentorId).last_modified_time === result.last_modified_time
     ) {
-      modifiedMentorIds.push(mentorId);
-    } else {
       unmodifiedMentorIds.add(mentorId);
     }
   }
@@ -126,10 +126,10 @@ exports.handler = async (event) => {
   const indexMentors = [...mentorMap.entries()].filter(
     ([mentorId, mentor]) => !unmodifiedMentorIds.has(mentorId) && mentor.name
   );
+  console.log(indexMentors);
 
   console.log(`No. of Elasticsearch mentors: ${count}`);
   console.log(`No. of deleted mentors: ${deletedMentorIds.length}`);
-  console.log(`No. of modified mentors: ${modifiedMentorIds.length}`);
   console.log(`No. of index mentors: ${indexMentors.length}`);
 
   if (deletedMentorIds.length > 0) {


### PR DESCRIPTION
I filtered out Airtable entries which are nameless when updating the ElasticSearch, which should act as a backup method to stop the issue. I also added back the functionality to add new mentors from the Airtable to the ElasticSearch
