### PR TITLE
[MPT-28] fix: public_url for logo

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,10 +10,10 @@ export default function App({ Component, pageProps }: AppProps) {
         <meta charset="utf-8" />
         <title>Advisory Mentorship Programme</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+        <link rel="icon" href="/favicon.ico" />
         <meta name="theme-color" content="#000000" />
-        <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-        <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+        <link rel="apple-touch-icon" href="/logo192.png" />
+        <link rel="manifest" href="/manifest.json" />
         <meta name="description" content="The Advisory Mentorship Programme" />
         // Google
         <meta itemprop="name" content="Advisory Mentorship Programme" />
@@ -21,10 +21,7 @@ export default function App({ Component, pageProps }: AppProps) {
           itemprop="description"
           content="The Advisory Mentorship Programme"
         />
-        <meta
-          itemprop="image"
-          content="%PUBLIC_URL%/advisory-mentorship-logo.jpg"
-        />
+        <meta itemprop="image" content="/advisory-mentorship-logo.jpg" />
         // Facebook / OpenGraph
         <meta property="og:url" content="https://mentorship.advisory.sg" />
         <meta property="og:type" content="website" />
@@ -33,10 +30,7 @@ export default function App({ Component, pageProps }: AppProps) {
           property="og:description"
           content="The Advisory Mentorship Programme"
         />
-        <meta
-          property="og:image"
-          content="%PUBLIC_URL%/advisory-mentorship-logo.jpg"
-        />
+        <meta property="og:image" content="/advisory-mentorship-logo.jpg" />
         // Twitter
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content="Advisory Mentorship Programme" />
@@ -44,10 +38,7 @@ export default function App({ Component, pageProps }: AppProps) {
           name="twitter:description"
           content="The Advisory Mentorship Programme"
         />
-        <meta
-          name="twitter:image"
-          content="%PUBLIC_URL%/advisory-mentorship-logo.jpg"
-        />
+        <meta name="twitter:image" content="/advisory-mentorship-logo.jpg" />
         <script
           async
           src="https://umami.advisory.sg/script.js"


### PR DESCRIPTION
For now using a relative path for ease of development. If we want an absolute path to the image we may need to create configuration variables to reference.

https://vercel.com/docs/concepts/projects/environment-variables
https://github.com/vercel/next.js/discussions/16429