### PR TITLE
[MPT-27] umami: add tracking events

### DIFF
--- a/components/ResultViewGrid.tsx
+++ b/components/ResultViewGrid.tsx
@@ -55,6 +55,9 @@ const ResultViewGrid = ({
           height: "100%",
         }}
         data-umami-event="Read more (grid view)"
+        data-umami-event-name={displayName}
+        data-umami-event-organisation={displayOrganisation}
+        data-umami-event-role={displayRole}
       >
         <CardMedia
           component="img"
@@ -100,6 +103,9 @@ const ResultViewGrid = ({
             onClick={handleOpen}
             style={{ fontSize: 12 }}
             data-umami-event="Read more (grid view)"
+            data-umami-event-name={displayName}
+            data-umami-event-organisation={displayOrganisation}
+            data-umami-event-role={displayRole}
           >
             Read More
           </Button>

--- a/components/ResultViewGrid.tsx
+++ b/components/ResultViewGrid.tsx
@@ -54,6 +54,7 @@ const ResultViewGrid = ({
           justifyContent: "flex-start",
           height: "100%",
         }}
+        data-umami-event="Read more (grid view)"
       >
         <CardMedia
           component="img"
@@ -95,7 +96,11 @@ const ResultViewGrid = ({
         <CardActions
           style={{ display: "flex", flexGrow: 1, alignItems: "flex-end" }}
         >
-          <Button onClick={handleOpen} style={{ fontSize: 12 }}>
+          <Button
+            onClick={handleOpen}
+            style={{ fontSize: 12 }}
+            data-umami-event="Read more (grid view)"
+          >
             Read More
           </Button>
         </CardActions>

--- a/components/ResultViewList.tsx
+++ b/components/ResultViewList.tsx
@@ -122,6 +122,9 @@ const ResultViewList = ({
                       ? "Read less (list view)"
                       : "Read more (list view)"
                   }
+                  data-umami-event-name={displayName}
+                  data-umami-event-organisation={displayOrganisation}
+                  data-umami-event-role={displayRole}
                 >
                   {isReadMore ? "Read Less" : "Read More"}
                 </a>

--- a/components/ResultViewList.tsx
+++ b/components/ResultViewList.tsx
@@ -117,6 +117,11 @@ const ResultViewList = ({
                     e.preventDefault();
                     setIsReadMore(!isReadMore);
                   }}
+                  data-umami-event={
+                    isReadMore
+                      ? "Read less (list view)"
+                      : "Read more (list view)"
+                  }
                 >
                   {isReadMore ? "Read Less" : "Read More"}
                 </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -130,7 +130,11 @@ const Index = () => {
                       indicatorColor="primary"
                     >
                       {WAVES.map(({ waveName }) => (
-                        <Tab key={waveName} label={waveName} />
+                        <Tab
+                          key={waveName}
+                          label={waveName}
+                          data-umami-event={`Tab '${waveName}'`}
+                        />
                       ))}
                     </Tabs>
                   </div>
@@ -178,6 +182,7 @@ const Index = () => {
                           color={isListView ? "default" : "primary"}
                           onClick={() => setIsListView(false)}
                           size={isSmall ? "small" : "medium"}
+                          data-umami-event={"Grid view"}
                         >
                           <GridViewIcon />
                         </IconButton>
@@ -186,6 +191,7 @@ const Index = () => {
                           color={isListView ? "primary" : "default"}
                           onClick={() => setIsListView(true)}
                           size={isSmall ? "small" : "medium"}
+                          data-umami-event={"List view"}
                         >
                           <ViewListIcon />
                         </IconButton>


### PR DESCRIPTION
The following events are now tracked:
1. `Tab ${tabName}`
2. "Grid view"/"List view"
2. "Read more (grid view)"
3. "Read more (list view)"/"Read less (list view)"

Closes https://github.com/AdvisorySG/mentorship-page/issues/607.