### PR TITLE
[MPT-32] mentors: fix formatting #606 

### DIFF
--- a/components/ResultViewGrid.tsx
+++ b/components/ResultViewGrid.tsx
@@ -39,9 +39,9 @@ const ResultViewGrid = ({
 
   return (
     <Card
-      className="sui-result"
+      className="sui-resultgrid"
       style={{
-        maxWidth: "165px",
+        width: "180px",
         padding: "0px",
       }}
     >
@@ -60,7 +60,7 @@ const ResultViewGrid = ({
           image={thumbnailImageUrl}
           style={{
             width: "100%",
-            height: "163px",
+            height: "180px",
           }}
         />
         <CardContent>

--- a/styles/ResultView.css
+++ b/styles/ResultView.css
@@ -1,5 +1,7 @@
+.sui-resultgrid,
 .sui-result {
   display: flex;
+  box-sizing: border-box;
 }
 
 .sui-result + .sui-result {
@@ -36,6 +38,7 @@
 }
 
 @media only screen and (max-width: 800px) {
+  .sui-resultgrid,
   .sui-result {
     flex-direction: column;
   }
@@ -95,7 +98,7 @@
 .sui-result__modal {
   display: flex;
   align-items: center;
-  margin: auto;
+  margin: 0 auto;
   max-width: 800px;
   max-height: 80%;
   overflow: scroll;

--- a/styles/ResultView.css
+++ b/styles/ResultView.css
@@ -98,7 +98,7 @@
 .sui-result__modal {
   display: flex;
   align-items: center;
-  margin: 0 auto;
+  margin: auto;
   max-width: 800px;
   max-height: 80%;
   overflow: scroll;

--- a/styles/ResultView.module.css
+++ b/styles/ResultView.module.css
@@ -1,6 +1,8 @@
+.sui-resultgrid,
 .sui-result {
   display: flex;
   @media only screen and (max-width: 800px) {
+    .sui-resultgrid,
     .sui-result {
       flex-direction: column;
     }
@@ -42,7 +44,7 @@
 }
 
 .sui-result + .sui-result {
-  margin-top: 0px;
+  margin-top: 32px;
 }
 
 .sui-result__body {

--- a/styles/ResultView.module.css
+++ b/styles/ResultView.module.css
@@ -44,7 +44,7 @@
 }
 
 .sui-result + .sui-result {
-  margin-top: 32px;
+  margin-top: 0px;
 }
 
 .sui-result__body {


### PR DESCRIPTION
fixed formatting issue where the 1st mentor card in the grid format is misaligned with the other mentor card