### PR TITLE
fix: attempt to fix issue #519 MPT-14 through clicking the search button

### DIFF
--- a/pages/mentors.tsx
+++ b/pages/mentors.tsx
@@ -93,11 +93,11 @@ const App = () => {
     },
   };
 
-  const button = document.querySelector(
-    'input[class="button sui-search-box__submit"]'
-  ) as HTMLButtonElement;
   const handleTabChange = (_: React.ChangeEvent<{}>, tab: number) => {
     setCurrentTabId(tab);
+    const button = document.querySelector(
+      'input[class="button sui-search-box__submit"]'
+    ) as HTMLButtonElement;
     if (button) {
       button.click();
     }

--- a/pages/mentors.tsx
+++ b/pages/mentors.tsx
@@ -31,8 +31,8 @@ const App = () => {
 
   const [isListView, setIsListView] = useState(false);
   const WAVES = [
-    { waveId: 4, waveName: "VJC Mentorship 2023" },
     { waveId: 5, waveName: "Wave 2023" },
+    { waveId: 4, waveName: "VJC Mentorship 2023" },
   ];
   const [currentTabId, setCurrentTabId] = useState(0);
 

--- a/pages/mentors.tsx
+++ b/pages/mentors.tsx
@@ -30,7 +30,10 @@ const App = () => {
   const isSmall = useMediaQuery("(max-width: 800px)");
 
   const [isListView, setIsListView] = useState(false);
-  const WAVES = [{ waveId: 4, waveName: "VJC Mentorship 2023" }];
+  const WAVES = [
+    { waveId: 4, waveName: "VJC Mentorship 2023" },
+    { waveId: 5, waveName: "Wave 2023" },
+  ];
   const [currentTabId, setCurrentTabId] = useState(0);
 
   const connector = new AppSearchAPIConnector({
@@ -90,8 +93,15 @@ const App = () => {
     },
   };
 
-  const handleTabChange = (_: React.ChangeEvent<{}>, tab: number) =>
+  const button = document.querySelector(
+    'input[class="button sui-search-box__submit"]'
+  ) as HTMLButtonElement;
+  const handleTabChange = (_: React.ChangeEvent<{}>, tab: number) => {
     setCurrentTabId(tab);
+    if (button) {
+      button.click();
+    }
+  };
 
   return (
     <div className="results" id="mentors">

--- a/pages/mentors.tsx
+++ b/pages/mentors.tsx
@@ -95,6 +95,8 @@ const App = () => {
 
   const handleTabChange = (_: React.ChangeEvent<{}>, tab: number) => {
     setCurrentTabId(tab);
+    // FIXME: Hacky solution to identify the search button by Elastic Search UI
+    // and trigger a click to reset search results
     const button = document.querySelector(
       'input[class="button sui-search-box__submit"]'
     ) as HTMLButtonElement;


### PR DESCRIPTION
I first revert to multi-tab by doing the following
```javascript
const WAVES = [
    { waveId: 4, waveName: "VJC Mentorship 2023" },
    { waveId: 5, waveName: "Wave 2023" },
  ];
```

Then I noticed that the search result reset to the first page with you click the search button which has the class name `button sui-search-box__submit`

Therefore, I identified the element and simulated a click after the tab switch as shown
 ```javascript
const handleTabChange = (_: React.ChangeEvent<{}>, tab: number) => {
    setCurrentTabId(tab);
    const button = document.querySelector(
      'input[class="button sui-search-box__submit"]'
    ) as HTMLButtonElement;
    if (button) {
      button.click();
    }
  };
  ```