### PR TITLE
Add a width attribute to the Card component and set it to 100%

### DIFF
--- a/components/ResultViewGrid.tsx
+++ b/components/ResultViewGrid.tsx
@@ -42,6 +42,8 @@ const ResultViewGrid = ({
       className="sui-result"
       style={{
         maxWidth: "165px",
+        width: "100%",
+        height: "auto", 
         padding: "0px",
       }}
     >

--- a/components/ResultViewGrid.tsx
+++ b/components/ResultViewGrid.tsx
@@ -43,7 +43,7 @@ const ResultViewGrid = ({
       style={{
         maxWidth: "165px",
         width: "100%",
-        height: "auto", 
+        height: "auto",
         padding: "0px",
       }}
     >


### PR DESCRIPTION
The `max-width` attribute is still set to 165px, so there should be no awkward sizing issues. 

Before:
<img width="681" alt="image" src="https://github.com/AdvisorySG/mentorship-page/assets/35882565/66238e8a-0dc5-40a1-8a83-817ca3d6f3fd">



After:
<img width="692" alt="image" src="https://github.com/AdvisorySG/mentorship-page/assets/35882565/1b6f97de-6adf-43bb-ab2d-7b0dd7c65176">
