### PR TITLE
[MPT-40] Mentors: Search bar is much wider than mentors grid

### DIFF
--- a/styles/App.css
+++ b/styles/App.css
@@ -55,6 +55,8 @@ body {
 
 .sui-layout-header {
   padding-bottom: 0px;
+  width: 75%;
+  margin: auto;
 }
 
 .sui-layout-main-header__inner {


### PR DESCRIPTION
I made search bar not span the entire page and I also centered it