### PR TITLE
feat: new privacy modal based on MPT-53

### DIFF
--- a/components/PrivacyNote.tsx
+++ b/components/PrivacyNote.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from "react";
+import Modal from "@mui/material/Modal";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import Cookies from "js-cookie";
+
+// References:
+// How to make the Modal: https://mui.com/material-ui/react-modal/
+// How to use Cookie: https://www.telerik.com/blogs/react-basics-how-to-use-cookies
+
+const style = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "80%",
+  maxWidth: "600px",
+  bgcolor: "background.paper",
+  border: "2px solid #000",
+  boxShadow: 24,
+  p: 4,
+};
+
+function PrivacyModal() {
+  // Default assume the person has the cookie so don't need privacy banner
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Check if the cookie is true
+  useEffect(() => {
+    const hasAgreed = Cookies.get("userAgreedToPrivacyPolicy");
+    if (!hasAgreed) {
+      setIsOpen(true);
+    }
+  }, []);
+
+  // Function to change it to true
+  const handleAgree = () => {
+    Cookies.set("userAgreedToPrivacyPolicy", true, { expires: 30 });
+    setIsOpen(false);
+  };
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={handleAgree}
+      aria-labelledby="privacy-policy-title"
+      aria-describedby="privacy-policy-description"
+    >
+      <Box sx={style}>
+        <Typography id="privacy-policy-title" variant="h6" component="h2">
+          Privacy Policy
+        </Typography>
+        <Typography id="privacy-policy-description" sx={{ mt: 2 }}>
+          The privacy and safety of our mentors are of utmost priority to
+          Advisory. Any attempt to approach or contact our mentors outside of
+          the parameters of the Advisory Mentorship Programme—whilst claiming
+          affiliation to Advisory, or misrepresenting a relationship to
+          Advisory—will be treated as misrepresentation, even fraudulent
+          misrepresentation, as considered under the Misrepresentation Act.
+          Advisory will take legal action against any individuals or
+          organisations who attempt to deceive, harass, or otherwise request
+          dishonest assistance from our mentors.
+        </Typography>
+        <Button onClick={handleAgree} style={{ marginTop: "20px" }}>
+          Agree
+        </Button>
+      </Box>
+    </Modal>
+  );
+}
+
+export default PrivacyModal;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.11.16",
         "html-to-text": "^9.0.5",
+        "js-cookie": "^3.0.5",
         "next": "^13.5.5",
         "react": "^18.2.0"
       },
@@ -2146,6 +2147,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.11.16",
     "html-to-text": "^9.0.5",
+    "js-cookie": "^3.0.5",
     "next": "^13.5.5",
     "react": "^18.2.0"
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,8 @@ import Script from "next/script";
 import "../styles/App.css";
 import "../styles/globals.css";
 
+import PrivacyModal from "../components/PrivacyNote.tsx";
+
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
@@ -52,6 +54,7 @@ export default function App({ Component, pageProps }: AppProps) {
         data-website-id="2f694eab-769e-420a-bb31-4efcb3662bf5"
       />
       <Component {...pageProps} />
+      <PrivacyModal />
     </>
   );
 }


### PR DESCRIPTION
This is a pull request in response to [issue #683](https://github.com/AdvisorySG/mentorship-page/issues/683) 

I make a very simple cookie to track if the agreement button has been clicked. It is also applied to all pages because I inserted the component in `_app.tsx`. 

I am not sure about the Modal format so I just follow the convention and have a component for the privacy banner. 

