### PR TITLE
[MPT-70] New clear filter button

### DIFF
--- a/components/ResetButton.tsx
+++ b/components/ResetButton.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { withSearch } from "@elastic/react-search-ui";
+
+function ClearFacets({ filters, removeFilter }) {
+  const handleClearAll = () => {
+    for (const filter of filters) {
+      removeFilter(filter.field, filter.value);
+    }
+  };
+
+  const [isHovered, setIsHovered] = useState(false);
+
+  const buttonStyle = {
+    backgroundColor: "#fff",
+    color: "#333",
+    border: "1px solid #ccc",
+    borderRadius: "4px",
+    padding: "10px 20px",
+    fontSize: "14px",
+    cursor: "pointer",
+    margin: "10px 0",
+    transition: "all 0.3s ease",
+    outline: "none",
+    width: "100%",
+    display: "block",
+  };
+
+  const buttonHoverStyle = {
+    ...buttonStyle,
+    backgroundColor: "#f8f8f8",
+    borderColor: "#bbb",
+  };
+
+  return (
+    <button
+      style={isHovered ? buttonHoverStyle : buttonStyle}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onClick={handleClearAll}
+    >
+      Clear All Filters
+    </button>
+  );
+}
+
+export default withSearch(({ filters, removeFilter }) => ({
+  filters,
+  removeFilter,
+}))(ClearFacets);

--- a/pages/mentors/[id].tsx
+++ b/pages/mentors/[id].tsx
@@ -30,6 +30,8 @@ import { Link } from "@mui/material";
 import type { GetStaticProps, GetStaticPaths } from "next";
 import { useRouter } from "next/router";
 
+import ClearFacets from "../../components/ResetButton";
+
 // This also gets called at build time
 export const getStaticProps: GetStaticProps = async (context) => {
   // params contains the mentors page `id`.
@@ -200,6 +202,7 @@ const App = () => {
                   filterType="any"
                   label="Course of Study"
                 />
+                <ClearFacets />
               </div>
             }
             bodyHeader={


### PR DESCRIPTION
### Description:
This pull request introduces a new "Clear Filters" button that allows users to easily reset all applied filters on the page. It is to address issue [\[MPT-70\]](https://github.com/AdvisorySG/mentorship-page/issues/723)

### Technical details:
A new component called `ResetButton.tsx` was created to handle the clearing functionality.
The button utilizes the existing `removeFilter` function to clear individual filters.
The component has a function that loops through the `filter` and clears them individually.

```
const handleClearAll = () => {
  for (const filter of filters) {
    removeFilter(filter.field, filter.value);
  }
};
```

### Reference:
- https://discuss.elastic.co/t/selectedfilter-resetsearchbutton/275284