### PR TITLE
[MPT-66] Home: Carousel arrows are flipped on narrow displays

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -344,7 +344,7 @@ const Index = () => {
                 fontSize: "24px",
                 color: "var(--brand-color)",
                 margin: "10px",
-                marginLeft: isSmall ? "20%" : "25%",
+                marginLeft: isSmall ? "12.5%" : "25%",
                 position: "absolute",
               }}
             >
@@ -360,7 +360,7 @@ const Index = () => {
                 color: "var(--brand-color)",
                 margin: "10px",
                 position: "absolute",
-                marginRight: isSmall ? "20%" : "25%",
+                marginRight: isSmall ? "12.5%" : "25%",
               }}
             >
               {">"}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -344,7 +344,7 @@ const Index = () => {
                 fontSize: "24px",
                 color: "var(--brand-color)",
                 margin: "10px",
-                marginLeft: isSmall ? "0" : "300px",
+                marginLeft: isSmall ? "20%" : "25%",
                 position: "absolute",
               }}
             >
@@ -360,7 +360,7 @@ const Index = () => {
                 color: "var(--brand-color)",
                 margin: "10px",
                 position: "absolute",
-                marginRight: isSmall ? "0" : "300px",
+                marginRight: isSmall ? "20%" : "25%",
               }}
             >
               {">"}


### PR DESCRIPTION
I modified the margin-left and margin-right of the arrows such that they make use of a percentage value for the margin instead of a fix value of 0 and 300px. This prevents the carousel arrows to be flipped on narrow displays.