### PR TITLE
[MPT-68] Search bar is narrow on mobile phone 

### DIFF
--- a/components/ResultViewGrid.tsx
+++ b/components/ResultViewGrid.tsx
@@ -41,7 +41,6 @@ const ResultViewGrid = ({
     <Card
       className="sui-resultgrid"
       style={{
-        maxWidth: "165px",
         width: "100%",
         height: "auto",
         padding: "0px",

--- a/styles/App.css
+++ b/styles/App.css
@@ -101,6 +101,13 @@ body {
   margin: auto;
 }
 
+@media only screen and (max-width: 800px) {
+  .sui-layout-header {
+    width: 100%;
+    padding: 32px 15px !important;
+  }
+}
+
 .sui-layout-main-header__inner {
   gap: 10px;
 }

--- a/styles/ResultView.css
+++ b/styles/ResultView.css
@@ -2,6 +2,8 @@
 .sui-result {
   display: flex;
   box-sizing: border-box;
+  flex-basis: 165px;
+  flex-grow: 1;
 }
 
 .sui-result + .sui-result {


### PR DESCRIPTION
# Change 1: Increasing size of search bar
Old implementation:
![telegram-cloud-photo-size-5-6303133767425964763-y](https://github.com/AdvisorySG/mentorship-page/assets/62941997/20eda27d-8e5e-43b4-93ef-884b330e6a83)

New implementation:
![telegram-cloud-photo-size-5-6303133767425964762-y](https://github.com/AdvisorySG/mentorship-page/assets/62941997/b8ae1fca-28bb-45ac-985c-93c2032ebb09)

# Change 2: Dynamically resizing mentor images to fit available width
This additional change was requested by Wei En
![localhost_3000_mentors_0_size=n_20_n(iPhone 12 Pro)](https://github.com/AdvisorySG/mentorship-page/assets/62941997/a1a47c44-4bbb-4e4e-bbc8-325a695b78b0)