### PR TITLE
[MPT-110] Fix Testimonial Carousel

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import Glide from "@glidejs/glide";
 import "@glidejs/glide/dist/css/glide.core.min.css";
 import "@glidejs/glide/dist/css/glide.theme.min.css";
@@ -110,11 +110,6 @@ const Index = () => {
     }
   }
 
-  useEffect(() => {
-    setTimeout(initializeGlide, 500);
-    return () => destroyGlide();
-  }, []);
-
   function debounce(func, delay) {
     let timer;
     return function () {
@@ -126,6 +121,17 @@ const Index = () => {
       }, delay);
     };
   }
+
+  const refreshGlide = debounce(function () {
+    console.log(`Refresh ${isSmall}`);
+    destroyGlide(); // Clear any past instance
+    initializeGlide();
+  }, 500);
+
+  useEffect(() => {
+    refreshGlide();
+    return () => destroyGlide();
+  }, []);
 
   const debouncedResize = debounce(function () {
     if (glideTestimonial) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -111,8 +111,7 @@ const Index = () => {
   }
 
   useEffect(() => {
-    initializeGlide();
-
+    setTimeout(initializeGlide, 500);
     return () => destroyGlide();
   }, []);
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -123,7 +123,6 @@ const Index = () => {
   }
 
   const refreshGlide = debounce(function () {
-    console.log(`Refresh ${isSmall}`);
     destroyGlide(); // Clear any past instance
     initializeGlide();
   }, 500);


### PR DESCRIPTION
Initial Issue - Mobile view/ other view bugs out
<img width="472" alt="image" src="https://github.com/AdvisorySG/mentorship-page/assets/18213722/d5a476ba-04bb-4765-9e06-07efe0effdc8">

Suspected root cause of the issue is the `isSmall` variable

```
const Index = () => {
  const isSmall = useMediaQuery("(max-width: 800px)");
  const glideRef = useRef(null);
```

When the component is first initialised, the value is ALWAYS false, regardless of orientation. It is then rendered once. This variable is then updated, but the component is not rerendered/ reinitialised after the variable update. The buggy mentor/ mentee listing (and hence offset) would then appear.

The PR initialises the Carousel only AFTER the media query is properly updated (a timeout is a simple enough fix, `useEffect` might be too complicated and interfere with the React Lifecycle). The component would then be rendered with the proper props & styling

Can compare with breakpoint 613 before and after. Before, the carousel overflows. After, the carousel doesn't overflow

Before
<img width="581" alt="image" src="https://github.com/AdvisorySG/mentorship-page/assets/18213722/60cafc3b-42d2-4856-b78e-0cb0488daf32">

After
<img width="536" alt="image" src="https://github.com/AdvisorySG/mentorship-page/assets/18213722/8037dfd9-49ff-4fe9-897e-2da0140a30d1">

This issue took quite a while to debug