### PR TITLE
[MPT-116] feat(umami): record document ID + process env in impression/click

### DIFF
--- a/components/ResultView.tsx
+++ b/components/ResultView.tsx
@@ -86,6 +86,7 @@ const COLORS = [
 const industryColors = new Map();
 
 type DisplayResult = {
+  id: string;
   displayName: string | null;
   displayIndustries: Array<string>;
   displayRole: string | null;
@@ -100,6 +101,7 @@ type DisplayResult = {
 
 const ResultView = ({ result }: { result: SearchResult }) => {
   const {
+    id: idObj,
     course_of_study: courseOfStudy,
     full_bio: fullBio,
     industries,
@@ -109,6 +111,8 @@ const ResultView = ({ result }: { result: SearchResult }) => {
     school,
     thumbnail_image_url,
   } = result;
+
+  const id = idObj.raw;
 
   const displayName =
     name && name.raw ? fillHighlights(name.snippet, name.raw) : null;
@@ -149,6 +153,7 @@ const ResultView = ({ result }: { result: SearchResult }) => {
       : null;
 
   const displayResult: DisplayResult = {
+    id,
     displayCourseOfStudy,
     displayFullBio,
     displayIndustries,

--- a/components/ResultViewGrid.tsx
+++ b/components/ResultViewGrid.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, lazy, Suspense } from "react";
 import { Modal, Button, CardActionArea } from "@mui/material";
+import { useInView } from "react-intersection-observer";
 
 import type { DisplayResult } from "./ResultView";
 const LazyResultViewList = lazy(() => import("./ResultViewList"));
@@ -15,6 +16,8 @@ const ResultViewGrid = ({
 }: {
   displayResult: DisplayResult;
 }) => {
+  const { ref, inView } = useInView();
+
   const {
     id,
     displayName,
@@ -25,7 +28,7 @@ const ResultViewGrid = ({
 
   useEffect(() => {
     window.umami.track("Impression", { id, env: process.env.NODE_ENV });
-  }, [id]);
+  }, [id, inView]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -55,6 +58,7 @@ const ResultViewGrid = ({
         height: "auto",
         padding: "0px",
       }}
+      ref={ref}
     >
       <CardActionArea
         onClick={handleOpen}

--- a/components/ResultViewGrid.tsx
+++ b/components/ResultViewGrid.tsx
@@ -15,14 +15,24 @@ const ResultViewGrid = ({
 }: {
   displayResult: DisplayResult;
 }) => {
-  const { displayName, displayOrganisation, displayRole, thumbnailImageUrl } =
-    displayResult;
+  const {
+    id,
+    displayName,
+    displayOrganisation,
+    displayRole,
+    thumbnailImageUrl,
+  } = displayResult;
+
+  useEffect(() => {
+    window.umami.track("Impression", { id, env: process.env.NODE_ENV });
+  }, [id]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleOpen = () => {
     window.history.pushState({}, "");
     setIsModalOpen(true);
+    window.umami.track("Click", { id, env: process.env.NODE_ENV });
   };
 
   const handleClose = () => {
@@ -55,10 +65,6 @@ const ResultViewGrid = ({
           justifyContent: "flex-start",
           height: "100%",
         }}
-        data-umami-event="Read more"
-        data-umami-event-name={displayName}
-        data-umami-event-organisation={displayOrganisation}
-        data-umami-event-role={displayRole}
       >
         <CardMedia
           component="img"
@@ -100,14 +106,7 @@ const ResultViewGrid = ({
         <CardActions
           style={{ display: "flex", flexGrow: 1, alignItems: "flex-end" }}
         >
-          <Button
-            onClick={handleOpen}
-            style={{ fontSize: 12 }}
-            data-umami-event="Read more"
-            data-umami-event-name={displayName}
-            data-umami-event-organisation={displayOrganisation}
-            data-umami-event-role={displayRole}
-          >
+          <Button onClick={handleOpen} style={{ fontSize: 12 }}>
             Read More
           </Button>
         </CardActions>

--- a/components/ResultViewGrid.tsx
+++ b/components/ResultViewGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, lazy, Suspense } from "react";
+import React, { Suspense, lazy, useEffect, useRef, useState } from "react";
 import { Modal, Button, CardActionArea } from "@mui/material";
 import { useInView } from "react-intersection-observer";
 
@@ -26,8 +26,12 @@ const ResultViewGrid = ({
     thumbnailImageUrl,
   } = displayResult;
 
+  const inViewRef = useRef(false);
   useEffect(() => {
-    window.umami.track("Impression", { id, env: process.env.NODE_ENV });
+    if (!inViewRef.current && inView) {
+      inViewRef.current = true;
+      window.umami.track("Impression", { id, env: process.env.NODE_ENV });
+    }
   }, [id, inView]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "next": "^14.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^9.10.3",
         "styled-components": "^6.1.8"
       },
       "devDependencies": {
@@ -2954,6 +2955,20 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.10.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.10.3.tgz",
+      "integrity": "sha512-9NYfKwPZRovB6QJee7fDg0zz/SyYrqXtn5xTZU0vwLtLVBtfu9aZt1pVmr825REE49VPDZ7Lm5SNHjJBOTZHpA==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "^14.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.10.3",
     "styled-components": "^6.1.8"
   },
   "scripts": {


### PR DESCRIPTION
Due to changes in React 18, under Strict Mode, useEffect will be triggered twice upon render.
It is recommended to not override this behaviour, and to instead specify information distinguishing between development and production environment. See https://react.dev/learn/synchronizing-with-effects#sending-analytics for more details.

Closes https://github.com/AdvisorySG/mentorship-page/issues/799.