### PR TITLE
[MPT-163] feat: shareable mentor links (hash-based)

### DIFF
--- a/src/app/mentors/page.tsx
+++ b/src/app/mentors/page.tsx
@@ -19,18 +19,17 @@ import {
 } from "@elastic/react-search-ui";
 import { SortDirection } from "@elastic/search-ui";
 import ElasticsearchAPIConnector from "@elastic/search-ui-elasticsearch-connector";
+import {
+  ELASTIC_APIKEY,
+  ELASTIC_CLOUD_ID,
+  ELASTIC_INDEX,
+} from "../../lib/elastic";
 
 import Canvas from "../../components/Canvas";
 import ClearFacets from "../../components/ResetButton";
 import ResultView from "../../components/ResultView";
 import "@elastic/react-search-ui-views/lib/styles/styles.css";
 import "../../styles/App.css";
-
-const ELASTIC_CLOUD_ID =
-  "advisorysg-mentorship:YXAtc291dGhlYXN0LTEuYXdzLmZvdW5kLmlvOjQ0MyQ2ZmEzOTc4MzA5YWE0ZjNjOTkyMDZlOWZkZjI0Y2MwYSRmYTMwNDgzZDk4Mjk0YjNkYjQ2M2QzMTNiZWM2ZmZlZA==";
-const ELASTIC_APIKEY =
-  "SXR2d3RwZ0JTU3k1WVE3YzFFTzM6T2pCbEFlNFJyUXNHbTNUTkxCV3lyQQ=="; // exposed to client! should be read-only
-const ELASTIC_INDEX = "mentorship-page-current";
 
 const CustomSortFacetView: React.FC<FacetViewProps> = (props) => {
   const { options } = props;

--- a/src/app/mentors/page.tsx
+++ b/src/app/mentors/page.tsx
@@ -28,6 +28,7 @@ import {
 import Canvas from "../../components/Canvas";
 import ClearFacets from "../../components/ResetButton";
 import ResultView from "../../components/ResultView";
+import SharedMentorModal from "../../components/SharedMentorModal";
 import "@elastic/react-search-ui-views/lib/styles/styles.css";
 import "../../styles/App.css";
 
@@ -123,6 +124,7 @@ const App = () => {
 
   return (
     <Canvas>
+      <SharedMentorModal />
       <div className="results" id="mentors">
         <SearchProvider config={configurationOptions}>
           <div className="App">

--- a/src/app/mentors/page.tsx
+++ b/src/app/mentors/page.tsx
@@ -72,6 +72,20 @@ const App = () => {
   const configurationOptions = {
     alwaysSearchOnInitialLoad: true,
     apiConnector: connector,
+    // Preserve any URL hash (e.g. a `#mentor=<id>` shared link) that search-ui
+    // would otherwise drop when it serializes its own state to the query string.
+    // search-ui only reads the query string, never the hash, so keeping the
+    // hash here cannot trigger a re-query.
+    routingOptions: {
+      writeUrl: (
+        url: string,
+        { replaceUrl = false }: { replaceUrl?: boolean } = {},
+      ) => {
+        if (typeof window === "undefined") return;
+        const method = replaceUrl ? "replaceState" : "pushState";
+        window.history[method]({}, "", `?${url}${window.location.hash}`);
+      },
+    },
     autocompleteQuery: {
       suggestions: {
         types: {

--- a/src/components/CopyLinkButton.tsx
+++ b/src/components/CopyLinkButton.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+
+import CheckIcon from "@mui/icons-material/Check";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import { IconButton, Tooltip } from "@mui/material";
+
+// Floating button (top-right of the modal) that copies a shareable
+// `#mentor=<id>` link to the clipboard. Builds the URL from the id directly,
+// so it does not depend on the current URL already containing the hash.
+const CopyLinkButton = ({ mentorId }: { mentorId: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    const url = `${window.location.origin}${window.location.pathname}#mentor=${mentorId}`;
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch((err) => {
+        console.error("Could not copy link: ", err);
+      });
+  };
+
+  return (
+    <Tooltip
+      title={copied ? "Copied!" : "Copy link to this mentor"}
+      placement="top"
+    >
+      <IconButton
+        onClick={handleCopy}
+        size="medium"
+        style={{
+          position: "absolute",
+          top: "10px",
+          right: "10px",
+          backgroundColor: "var(--brand-color)",
+          color: "white",
+          boxShadow: "2px 2px 8px rgba(0,0,0,0.2)",
+          zIndex: 1,
+        }}
+        aria-label="copy link to this mentor"
+      >
+        {copied ? <CheckIcon /> : <ContentCopyIcon />}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default CopyLinkButton;

--- a/src/components/MentorModal.tsx
+++ b/src/components/MentorModal.tsx
@@ -1,0 +1,48 @@
+import { Suspense, lazy } from "react";
+
+import { Modal } from "@mui/material";
+
+import CopyLinkButton from "./CopyLinkButton";
+import type { DisplayResult } from "./ResultView";
+
+const LazyResultViewList = lazy(() => import("./ResultViewList"));
+
+// The mentor detail modal, shared by the per-card (in-memory) path and the
+// shared-link (fetched) path. The Modal's direct child must be a DOM element
+// so MUI can attach its ref — hence the wrapping <div>.
+const MentorModal = ({
+  displayResult,
+  open,
+  onClose,
+}: {
+  displayResult: DisplayResult;
+  open: boolean;
+  onClose: () => void;
+}) => {
+  return (
+    <Modal
+      className="sui-result__modal"
+      open={open}
+      onClose={onClose}
+      aria-labelledby="modal-title"
+      aria-describedby="modal-description"
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        margin: "auto",
+        maxWidth: "800px",
+        maxHeight: "80%",
+        overflow: "auto",
+      }}
+    >
+      <div style={{ position: "relative", width: "100%" }}>
+        <Suspense fallback={null}>
+          <LazyResultViewList displayResult={displayResult} />
+        </Suspense>
+        <CopyLinkButton mentorId={displayResult.id} />
+      </div>
+    </Modal>
+  );
+};
+
+export default MentorModal;

--- a/src/components/ResultView.tsx
+++ b/src/components/ResultView.tsx
@@ -1,20 +1,7 @@
 import React, { lazy, Suspense } from "react";
 
-import {
-  red,
-  pink,
-  deepPurple,
-  indigo,
-  blue,
-  cyan,
-  teal,
-  lightGreen,
-  yellow,
-  deepOrange,
-  brown,
-  blueGrey,
-} from "@mui/material/colors";
 import { SearchResult } from "@elastic/search-ui";
+import { assignIndustryColors } from "../lib/industryColors";
 import { htmlToText } from "html-to-text";
 
 const LazyResultViewGrid = lazy(() => import("./ResultViewGrid"));
@@ -67,23 +54,6 @@ const fillHighlights = (snippet: string | null, full: string): string => {
   );
   return full.replace(snippetRaw, styledSnippet);
 };
-
-const COLORS = [
-  red,
-  pink,
-  deepPurple,
-  indigo,
-  blue,
-  cyan,
-  teal,
-  lightGreen,
-  yellow,
-  deepOrange,
-  brown,
-  blueGrey,
-].map((color) => color[200]);
-
-const industryColors = new Map();
 
 type DisplayResult = {
   id: string;
@@ -145,11 +115,7 @@ const ResultView = ({ result }: { result: SearchResult }) => {
 
   const displayIndustries =
     industries && Array.isArray(industries.raw) ? industries.raw : [];
-  displayIndustries.forEach((industry: string) => {
-    if (!industryColors.has(industry)) {
-      industryColors.set(industry, COLORS[industryColors.size % COLORS.length]);
-    }
-  });
+  const industryColors = assignIndustryColors(displayIndustries);
 
   const displayCompetencies =
     competencies && Array.isArray(competencies.raw) ? competencies.raw : [];

--- a/src/components/ResultViewGrid.tsx
+++ b/src/components/ResultViewGrid.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   Button,
@@ -7,12 +7,11 @@ import {
   CardActions,
   CardContent,
   CardMedia,
-  Modal,
 } from "@mui/material";
 import { useInView } from "react-intersection-observer";
 
+import MentorModal from "./MentorModal";
 import type { DisplayResult } from "./ResultView";
-const LazyResultViewList = lazy(() => import("./ResultViewList"));
 import "../styles/ResultView.css";
 
 const ResultViewGrid = ({
@@ -129,25 +128,11 @@ const ResultViewGrid = ({
           <Button style={{ fontSize: 12 }}>Read More</Button>
         </CardActions>
       </Card>
-      <Modal
-        className="sui-result__modal"
+      <MentorModal
+        displayResult={displayResult}
         open={isModalOpen}
         onClose={handleClose}
-        aria-labelledby="modal-title"
-        aria-describedby="modal-description"
-        style={{
-          display: "flex",
-          alignItems: "flex-start",
-          margin: "auto",
-          maxWidth: "800px",
-          maxHeight: "80%",
-          overflow: "auto",
-        }}
-      >
-        <Suspense fallback={null}>
-          <LazyResultViewList displayResult={displayResult} />
-        </Suspense>
-      </Modal>
+      />
     </>
   );
 };

--- a/src/components/ResultViewGrid.tsx
+++ b/src/components/ResultViewGrid.tsx
@@ -42,7 +42,12 @@ const ResultViewGrid = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleOpen = () => {
-    window.history.pushState({}, "");
+    // Reflect the open mentor in the URL (preserving search-ui's query string)
+    // so the address bar is shareable. pushState fires neither hashchange nor
+    // popstate, so SharedMentorModal stays inert and no extra fetch happens.
+    const url = new URL(window.location.href);
+    url.hash = `mentor=${id}`;
+    window.history.pushState({}, "", url.toString());
     setIsModalOpen(true);
     if (window.umami) {
       window.umami.track("Click", { id, env: process.env.NODE_ENV });

--- a/src/components/SharedMentorModal.tsx
+++ b/src/components/SharedMentorModal.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+
+import { CircularProgress, Modal } from "@mui/material";
+
+import MentorModal from "./MentorModal";
+import type { DisplayResult } from "./ResultView";
+import { displayResultFromSource, fetchMentorById } from "../lib/mentorApi";
+
+// Reads `#mentor=<id>` from the URL hash.
+const getMentorIdFromHash = (): string | null => {
+  if (typeof window === "undefined") return null;
+  const hash = window.location.hash.startsWith("#")
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+  return new URLSearchParams(hash).get("mentor");
+};
+
+// Page-level modal that handles shared `#mentor=<id>` links. Fetches the one
+// mentor by id (so it works even when that mentor is not in the loaded result
+// set) and renders it via the shared MentorModal.
+const SharedMentorModal = () => {
+  const [mentorId, setMentorId] = useState<string | null>(null);
+  const [displayResult, setDisplayResult] = useState<DisplayResult | null>(
+    null,
+  );
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+
+  // Sync the mentor id from the hash on initial load and on back/forward.
+  useEffect(() => {
+    const sync = () => setMentorId(getMentorIdFromHash());
+    sync();
+    window.addEventListener("hashchange", sync);
+    window.addEventListener("popstate", sync);
+    return () => {
+      window.removeEventListener("hashchange", sync);
+      window.removeEventListener("popstate", sync);
+    };
+  }, []);
+
+  // Fetch the mentor whenever the hash id changes.
+  useEffect(() => {
+    if (!mentorId) {
+      setDisplayResult(null);
+      setStatus("idle");
+      return;
+    }
+    let cancelled = false;
+    setStatus("loading");
+    setDisplayResult(null);
+    fetchMentorById(mentorId).then((source) => {
+      if (cancelled) return;
+      if (!source) {
+        setStatus("error");
+        return;
+      }
+      setDisplayResult(displayResultFromSource(mentorId, source));
+      setStatus("idle");
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mentorId]);
+
+  // Clear the hash without risking navigation away from the site.
+  const handleClose = () => {
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + window.location.search,
+    );
+    setMentorId(null);
+  };
+
+  if (!mentorId) return null;
+
+  if (displayResult) {
+    return (
+      <MentorModal
+        displayResult={displayResult}
+        open={true}
+        onClose={handleClose}
+      />
+    );
+  }
+
+  // Loading / not-found states.
+  return (
+    <Modal
+      className="sui-result__modal"
+      open={true}
+      onClose={handleClose}
+      aria-labelledby="modal-title"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        margin: "auto",
+        maxWidth: "800px",
+        maxHeight: "80%",
+      }}
+    >
+      <div
+        style={{
+          background: "white",
+          padding: "2rem",
+          borderRadius: "8px",
+          textAlign: "center",
+          outline: "none",
+        }}
+      >
+        {status === "loading" ? <CircularProgress /> : <p>Mentor not found.</p>}
+      </div>
+    </Modal>
+  );
+};
+
+export default SharedMentorModal;

--- a/src/lib/elastic.ts
+++ b/src/lib/elastic.ts
@@ -1,0 +1,18 @@
+// Shared Elasticsearch connection config + REST endpoint derivation.
+// The API key is read-only and is already exposed to the client.
+
+export const ELASTIC_CLOUD_ID =
+  "advisorysg-mentorship:YXAtc291dGhlYXN0LTEuYXdzLmZvdW5kLmlvOjQ0MyQ2ZmEzOTc4MzA5YWE0ZjNjOTkyMDZlOWZkZjI0Y2MwYSRmYTMwNDgzZDk4Mjk0YjNkYjQ2M2QzMTNiZWM2ZmZlZA==";
+export const ELASTIC_APIKEY =
+  "SXR2d3RwZ0JTU3k1WVE3YzFFTzM6T2pCbEFlNFJyUXNHbTNUTkxCV3lyQQ=="; // exposed to client! should be read-only
+export const ELASTIC_INDEX = "mentorship-page-current";
+
+// Derive the Elasticsearch REST endpoint from the Cloud ID.
+// Cloud ID format: "<name>:<base64>"; the base64 decodes to
+// "<host:port>$<esNodeId>$<kibanaId>". Endpoint = https://<esNodeId>.<host:port>.
+export function getElasticEndpoint(): string {
+  const base64 = ELASTIC_CLOUD_ID.split(":")[1];
+  const decoded = atob(base64);
+  const [hostPort, esNodeId] = decoded.split("$");
+  return `https://${esNodeId}.${hostPort}`;
+}

--- a/src/lib/industryColors.ts
+++ b/src/lib/industryColors.ts
@@ -1,0 +1,45 @@
+import {
+  red,
+  pink,
+  deepPurple,
+  indigo,
+  blue,
+  cyan,
+  teal,
+  lightGreen,
+  yellow,
+  deepOrange,
+  brown,
+  blueGrey,
+} from "@mui/material/colors";
+
+const COLORS = [
+  red,
+  pink,
+  deepPurple,
+  indigo,
+  blue,
+  cyan,
+  teal,
+  lightGreen,
+  yellow,
+  deepOrange,
+  brown,
+  blueGrey,
+].map((color) => color[200]);
+
+// Module-level so colors stay consistent across every result/modal on the page.
+const industryColors = new Map<string, string>();
+
+// Assigns a stable color to each industry (first-seen order) and returns the
+// shared map. Idempotent for industries already assigned.
+export function assignIndustryColors(
+  industries: Array<string>,
+): Map<string, string> {
+  industries.forEach((industry) => {
+    if (!industryColors.has(industry)) {
+      industryColors.set(industry, COLORS[industryColors.size % COLORS.length]);
+    }
+  });
+  return industryColors;
+}

--- a/src/lib/mentorApi.ts
+++ b/src/lib/mentorApi.ts
@@ -1,0 +1,65 @@
+import { ELASTIC_APIKEY, ELASTIC_INDEX, getElasticEndpoint } from "./elastic";
+import { assignIndustryColors } from "./industryColors";
+import type { DisplayResult } from "../components/ResultView";
+
+// The raw `_source` fields the modal needs.
+export interface MentorSource {
+  name?: string;
+  organisation?: string;
+  role?: string;
+  course_of_study?: string;
+  full_bio?: string;
+  school?: string;
+  industries?: Array<string>;
+  competencies?: Array<string>;
+  thumbnail_image_url?: string;
+  full_image_url?: string;
+}
+
+// Fetches a single mentor document by its Elasticsearch _id.
+// Returns the _source, or null on 404 / network error.
+export async function fetchMentorById(
+  id: string,
+): Promise<MentorSource | null> {
+  try {
+    const res = await fetch(
+      `${getElasticEndpoint()}/${ELASTIC_INDEX}/_doc/${encodeURIComponent(id)}`,
+      { headers: { Authorization: `ApiKey ${ELASTIC_APIKEY}` } },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data?._source ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// Maps a raw _source (no search snippets/highlights) into the DisplayResult
+// shape the modal renders.
+export function displayResultFromSource(
+  id: string,
+  source: MentorSource,
+): DisplayResult {
+  const displayIndustries = Array.isArray(source.industries)
+    ? source.industries
+    : [];
+  const displayCompetencies = Array.isArray(source.competencies)
+    ? source.competencies
+    : [];
+  const fullBio = source.full_bio ?? null;
+
+  return {
+    id,
+    displayName: source.name ?? null,
+    displayIndustries,
+    displayCompetencies,
+    displayRole: source.role ?? null,
+    displayOrganisation: source.organisation ?? null,
+    displayCourseOfStudy: source.course_of_study ?? null,
+    displayFullBio: fullBio,
+    displayShortBio: fullBio,
+    displaySchool: source.school ?? null,
+    industryColors: assignIndustryColors(displayIndustries),
+    thumbnailImageUrl: source.thumbnail_image_url ?? undefined,
+  };
+}


### PR DESCRIPTION
> **WIP / draft** — opening early for visibility; do not merge yet.

## Summary

Revives #906 (shareable mentor links) with a different, simpler approach that avoids the issues that stalled the original PR.

- Share URLs use a URL **hash** (`/mentors#mentor=<id>`) instead of a `?mentor=` query param. The hash is invisible to Elastic search-ui (it only reads the query string), so it **cannot** trigger the repeated-Elasticsearch-query loop flagged on #906.
- A page-level `SharedMentorModal` reads the hash and **fetches the one mentor by `_id`**, so a shared link reliably opens the modal even for the ~235 of 435 mentors not on the loaded page (and regardless of active filters). This removes the need for the unfinished "reorder mentor to top" item.
- A "Copy link" button (with copied-state feedback) is added to the mentor modal; it builds the share URL directly from the id.
- The per-card modal keeps its instant, in-memory behavior; both paths render a shared `MentorModal`.
- A minimal `routingOptions.writeUrl` re-appends the hash to the URL search-ui writes, so a shared link's `#mentor=` survives in the address bar (safe — search-ui never reads the hash, so no re-query).

Net vs #906: drops the `qs` / `preserveTypesEncoder` / custom query-string machinery and the reorder-to-top item; replaces the routing override that caused re-queries with a hash + a single-doc fetch.

### Files
- `src/lib/elastic.ts` — ES config + REST endpoint derivation
- `src/lib/industryColors.ts` — extracted shared industry-color assignment
- `src/lib/mentorApi.ts` — `fetchMentorById` + `displayResultFromSource`
- `src/components/CopyLinkButton.tsx`, `MentorModal.tsx`, `SharedMentorModal.tsx`
- `src/components/ResultViewGrid.tsx`, `ResultView.tsx`, `src/app/mentors/page.tsx`

## Test Plan
- [x] Click a mentor card → modal opens instantly, no `_doc`/`_search` request fires
- [x] Copy-link button copies `…/mentors#mentor=<id>`; shows "Copied!" feedback
- [x] Open `…/mentors#mentor=<id>` for a mentor **not** on page 1 → modal opens after a brief fetch
- [x] Network: opening/closing modals triggers **no** repeated `_search` queries (only initial search + one `_doc`)
- [x] Shared link still opens the mentor even when active filters would exclude them
- [x] Invalid id → "Mentor not found."; back/forward behaves sanely
- [x] Shared link's `#mentor=` hash persists in the address bar after load

Supersedes #906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)